### PR TITLE
Invalidate cache on post meta update

### DIFF
--- a/enhanced-post-cache.php
+++ b/enhanced-post-cache.php
@@ -27,6 +27,10 @@ class Enhanced_Post_Cache {
 		add_action( 'clean_term_cache', array( $this, 'flush_cache' ) );
 		add_action( 'clean_post_cache',  array( $this, 'clean_post_cache' ), 10, 2 );
 
+		add_action( 'deleted_post_meta', array( $this, 'update_post_meta' ), 10, 2 );
+		add_action( 'updated_post_meta', array( $this, 'update_post_meta' ), 10, 2 );
+		add_action( 'added_post_meta', array( $this, 'update_post_meta' ), 10, 2 );
+
 		add_action( 'wp_updating_comment_count', array( $this, 'dont_clear_advanced_post_cache' ) );
 		add_action( 'wp_update_comment_count', array( $this, 'do_clear_advanced_post_cache' ) );
 
@@ -52,6 +56,11 @@ class Enhanced_Post_Cache {
 		if ( ! wp_is_post_revision( $post ) && ! wp_is_post_autosave( $post ) ) {
 			$this->flush_cache();
 		}
+	}
+
+	public function update_post_meta( $ignored, $post_id ) {
+		$post = get_post( $post_id );
+		$this->clean_post_cache( $post_id, $post );
 	}
 
 	public function flush_cache() {


### PR DESCRIPTION
WordPress out of the box doesn't not invalidate the posts cache group when add/edit/delete post meta is called. This is a problem because if you have a plugin that saves values in 
post meta and doesn't call the clean_post_cache function. 

This is an issue that I have flagged in core in this [issue](https://core.trac.wordpress.org/ticket/40669). Until this is merged into core, this PR is a work around. 